### PR TITLE
feat: 상점 등록 시 영업시간 설정 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
@@ -1106,6 +1107,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/src/features/store/components/BusinessHoursInput.tsx
+++ b/src/features/store/components/BusinessHoursInput.tsx
@@ -1,0 +1,251 @@
+import type { CheckedState } from "@radix-ui/react-checkbox";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  BusinessHours,
+  DaySchedule,
+} from "../types/store.types";
+
+const DAYS = [
+  { key: "monday", label: "월요일" },
+  { key: "tuesday", label: "화요일" },
+  { key: "wednesday", label: "수요일" },
+  { key: "thursday", label: "목요일" },
+  { key: "friday", label: "금요일" },
+  { key: "saturday", label: "토요일" },
+  { key: "sunday", label: "일요일" },
+] as const;
+
+// 시간 옵션 생성 (00:00 ~ 23:30, 30분 단위)
+const generateTimeOptions = () => {
+  const times: string[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 30) {
+      times.push(
+        `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`
+      );
+    }
+  }
+  return times;
+};
+
+const TIME_OPTIONS = generateTimeOptions();
+
+interface BusinessHoursInputProps {
+  value: BusinessHours | null;
+  onChange: (value: BusinessHours | null) => void;
+}
+
+export function BusinessHoursInput({
+  value,
+  onChange,
+}: BusinessHoursInputProps) {
+  const businessHours = value || {
+    schedule: {},
+    note: "",
+    breakTime: "",
+  };
+
+  const updateDay = (
+    day: string,
+    schedule: DaySchedule | undefined
+  ) => {
+    onChange({
+      ...businessHours,
+      schedule: {
+        ...businessHours.schedule,
+        [day]: schedule,
+      },
+    });
+  };
+
+  const copyToWeekdays = (sourceDay: string) => {
+    const source =
+      businessHours.schedule[
+        sourceDay as keyof typeof businessHours.schedule
+      ];
+    if (!source || "closed" in source) return;
+
+    const weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday"];
+    const newSchedule = { ...businessHours.schedule };
+    weekdays.forEach((day) => {
+      newSchedule[day as keyof typeof newSchedule] = { ...source };
+    });
+    onChange({ ...businessHours, schedule: newSchedule });
+  };
+
+  const copyToWeekend = (sourceDay: string) => {
+    const source =
+      businessHours.schedule[
+        sourceDay as keyof typeof businessHours.schedule
+      ];
+    if (!source || "closed" in source) return;
+
+    onChange({
+      ...businessHours,
+      schedule: {
+        ...businessHours.schedule,
+        saturday: { ...source },
+        sunday: { ...source },
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* 요일별 영업시간 */}
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-muted">
+            <tr>
+              <th className="px-4 py-2 text-left text-sm font-medium">요일</th>
+              <th className="px-4 py-2 text-left text-sm font-medium w-20">
+                영업
+              </th>
+              <th className="px-4 py-2 text-left text-sm font-medium">
+                오픈
+              </th>
+              <th className="px-4 py-2 text-left text-sm font-medium">
+                마감
+              </th>
+              <th className="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {DAYS.map(({ key, label }) => {
+              const schedule = businessHours.schedule[key];
+              const isOpen = schedule && !("closed" in schedule);
+
+              return (
+                <tr key={key} className="border-t">
+                  <td className="px-4 py-2 text-sm">{label}</td>
+                  <td className="px-4 py-2">
+                    <Checkbox
+                      checked={isOpen}
+                      onCheckedChange={(checked: CheckedState) => {
+                        updateDay(
+                          key,
+                          checked === true
+                            ? { open: "10:00", close: "22:00" }
+                            : { closed: true }
+                        );
+                      }}
+                    />
+                  </td>
+                  <td className="px-4 py-2">
+                    {isOpen ? (
+                      <Select
+                        value={schedule.open}
+                        onValueChange={(open) =>
+                          updateDay(key, { ...schedule, open })
+                        }
+                      >
+                        <SelectTrigger className="w-28">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {TIME_OPTIONS.map((time) => (
+                            <SelectItem key={time} value={time}>
+                              {time}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">─</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    {isOpen ? (
+                      <Select
+                        value={schedule.close}
+                        onValueChange={(close) =>
+                          updateDay(key, { ...schedule, close })
+                        }
+                      >
+                        <SelectTrigger className="w-28">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {TIME_OPTIONS.map((time) => (
+                            <SelectItem key={time} value={time}>
+                              {time}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">─</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    {isOpen && key === "monday" && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => copyToWeekdays(key)}
+                        className="text-xs"
+                      >
+                        평일에 복사
+                      </Button>
+                    )}
+                    {isOpen && key === "saturday" && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => copyToWeekend(key)}
+                        className="text-xs"
+                      >
+                        주말에 복사
+                      </Button>
+                    )}
+                    {!isOpen && (
+                      <span className="text-muted-foreground text-sm">
+                        휴무
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 브레이크타임 */}
+      <div className="space-y-2">
+        <Label className="text-sm">브레이크타임 (선택)</Label>
+        <Input
+          placeholder="예: 15:00-16:00"
+          value={businessHours.breakTime || ""}
+          onChange={(e) =>
+            onChange({ ...businessHours, breakTime: e.target.value })
+          }
+        />
+      </div>
+
+      {/* 비고 */}
+      <div className="space-y-2">
+        <Label className="text-sm">비고 (선택)</Label>
+        <Input
+          placeholder="예: 명절 당일 휴무"
+          value={businessHours.note || ""}
+          onChange={(e) =>
+            onChange({ ...businessHours, note: e.target.value })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/store/components/OperatingHoursModal.tsx
+++ b/src/features/store/components/OperatingHoursModal.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { BusinessHoursInput } from "./BusinessHoursInput";
+import type { BusinessHours } from "../types/store.types";
+
+interface OperatingHoursModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  is24Hours: boolean;
+  businessHours: BusinessHours | null;
+  onSave: (is24Hours: boolean, businessHours: BusinessHours | null) => void;
+}
+
+export function OperatingHoursModal({
+  open,
+  onOpenChange,
+  is24Hours: initialIs24Hours,
+  businessHours: initialBusinessHours,
+  onSave,
+}: OperatingHoursModalProps) {
+  const [is24Hours, setIs24Hours] = useState(initialIs24Hours);
+  const [businessHours, setBusinessHours] = useState<BusinessHours | null>(
+    initialBusinessHours
+  );
+
+  // 모달이 열릴 때 props의 값으로 state를 동기화
+  useEffect(() => {
+    if (open) {
+      setIs24Hours(initialIs24Hours);
+      setBusinessHours(initialBusinessHours);
+    }
+  }, [open, initialIs24Hours, initialBusinessHours]);
+
+  const handleSave = () => {
+    if (is24Hours) {
+      onSave(true, null);
+    } else {
+      // 모든 요일에 대해 명시적으로 값을 설정 (체크 안한 요일은 {closed: true})
+      const completeSchedule: BusinessHours = {
+        schedule: {
+          monday: businessHours?.schedule?.monday || { closed: true },
+          tuesday: businessHours?.schedule?.tuesday || { closed: true },
+          wednesday: businessHours?.schedule?.wednesday || { closed: true },
+          thursday: businessHours?.schedule?.thursday || { closed: true },
+          friday: businessHours?.schedule?.friday || { closed: true },
+          saturday: businessHours?.schedule?.saturday || { closed: true },
+          sunday: businessHours?.schedule?.sunday || { closed: true },
+        },
+        note: businessHours?.note,
+        breakTime: businessHours?.breakTime,
+      };
+      onSave(false, completeSchedule);
+    }
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    // Reset to initial values
+    setIs24Hours(initialIs24Hours);
+    setBusinessHours(initialBusinessHours);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>운영 정보 설정</DialogTitle>
+          <DialogDescription>
+            스토어의 운영시간을 설정해주세요. 24시간 운영이거나 요일별로
+            다르게 설정할 수 있습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {/* 24시간 영업 */}
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="is24hours"
+              checked={is24Hours}
+              onCheckedChange={(checked: CheckedState) => setIs24Hours(checked === true)}
+            />
+            <Label htmlFor="is24hours" className="font-medium">
+              24시간 영업
+            </Label>
+          </div>
+
+          {/* 요일별 영업시간 */}
+          {!is24Hours && (
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold">요일별 영업시간</Label>
+              <BusinessHoursInput
+                value={businessHours}
+                onChange={setBusinessHours}
+              />
+            </div>
+          )}
+
+          {is24Hours && (
+            <div className="p-4 bg-muted rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                24시간 영업으로 설정되었습니다. 요일별 영업시간은 저장되지
+                않습니다.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={handleCancel}>
+            취소
+          </Button>
+          <Button type="button" onClick={handleSave}>
+            저장
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/store/components/StoreRegistrationModal.tsx
+++ b/src/features/store/components/StoreRegistrationModal.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Plus, Search } from "lucide-react";
+import { Plus, Search, Clock } from "lucide-react";
 import type {
   CreateStoreFormData,
   CreateStoreDto,
@@ -35,6 +35,7 @@ import type {
 } from "../types/store.types";
 import { useCreateStore, useUpdateStore, useStore } from "@/hooks/useStores";
 import { AddressSearchDialog, type AddressData } from "./AddressSearchDialog";
+import { OperatingHoursModal } from "./OperatingHoursModal";
 
 interface StoreRegistrationModalProps {
   storeId?: string;
@@ -49,6 +50,7 @@ export function StoreRegistrationModal({
 }: StoreRegistrationModalProps = {}) {
   const [internalOpen, setInternalOpen] = useState(false);
   const [addressSearchOpen, setAddressSearchOpen] = useState(false);
+  const [operatingHoursOpen, setOperatingHoursOpen] = useState(false);
 
   // Use controlled or uncontrolled state
   const isControlled = controlledOpen !== undefined;
@@ -81,6 +83,7 @@ export function StoreRegistrationModal({
       latitude: "",
       longitude: "",
       is_24_hours: false,
+      business_hours: null,
       gacha_machine_count: "",
       verification_status: "pending",
       data_source: "admin_input",
@@ -109,7 +112,8 @@ export function StoreRegistrationModal({
         address_type: storeData.address_type || "",
         latitude: storeData.latitude?.toString(),
         longitude: storeData.longitude?.toString(),
-        is_24_hours: storeData.is_24_hours || undefined,
+        is_24_hours: storeData.is_24_hours || false,
+        business_hours: storeData.business_hours || null,
         gacha_machine_count: storeData.gacha_machine_count?.toString() || "",
         verification_status: storeData.verification_status,
         data_source: storeData.data_source || undefined,
@@ -143,6 +147,7 @@ export function StoreRegistrationModal({
         latitude: parseFloat(data.latitude),
         longitude: parseFloat(data.longitude),
         is_24_hours: data.is_24_hours,
+        business_hours: data.is_24_hours ? null : data.business_hours,
         gacha_machine_count: data.gacha_machine_count
           ? parseInt(data.gacha_machine_count)
           : undefined,
@@ -533,25 +538,25 @@ export function StoreRegistrationModal({
                   운영 정보
                 </h3>
 
-                <FormField
-                  control={form.control}
-                  name="is_24_hours"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                      <FormControl>
-                        <input
-                          type="checkbox"
-                          checked={field.value}
-                          onChange={field.onChange}
-                          className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary"
-                        />
-                      </FormControl>
-                      <div className="space-y-1 leading-none">
-                        <FormLabel>24시간 운영</FormLabel>
-                      </div>
-                    </FormItem>
-                  )}
-                />
+                <div className="space-y-2">
+                  <FormLabel>영업시간</FormLabel>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setOperatingHoursOpen(true)}
+                    className="w-full gap-2"
+                  >
+                    <Clock className="w-4 h-4" />
+                    {form.watch("is_24_hours")
+                      ? "24시간 영업"
+                      : form.watch("business_hours")
+                      ? "영업시간 설정됨"
+                      : "영업시간 설정"}
+                  </Button>
+                  <FormDescription className="text-xs">
+                    버튼을 클릭하여 영업시간을 설정하세요
+                  </FormDescription>
+                </div>
 
                 <FormField
                   control={form.control}
@@ -767,6 +772,17 @@ export function StoreRegistrationModal({
           form.setValue("zone_code", addressData.zoneCode);
           form.setValue("building_name", addressData.buildingName);
           form.setValue("address_type", addressData.addressType);
+        }}
+      />
+
+      <OperatingHoursModal
+        open={operatingHoursOpen}
+        onOpenChange={setOperatingHoursOpen}
+        is24Hours={form.watch("is_24_hours")}
+        businessHours={form.watch("business_hours")}
+        onSave={(is24Hours, businessHours) => {
+          form.setValue("is_24_hours", is24Hours);
+          form.setValue("business_hours", businessHours);
         }}
       />
     </Dialog>

--- a/src/features/store/types/store.types.ts
+++ b/src/features/store/types/store.types.ts
@@ -24,16 +24,27 @@ export type DataSource = 'user_submit' | 'admin_input' | 'crawling' | 'partner_a
 export type AddressType = 'R' | 'J'
 
 /**
- * Business hours structure
+ * Day schedule - either closed or with open/close times
+ */
+export type DaySchedule =
+  | { closed: true }
+  | { open: string; close: string }
+
+/**
+ * Business hours structure with schedule and metadata
  */
 export interface BusinessHours {
-  mon?: string
-  tue?: string
-  wed?: string
-  thu?: string
-  fri?: string
-  sat?: string
-  sun?: string
+  schedule: {
+    monday?: DaySchedule
+    tuesday?: DaySchedule
+    wednesday?: DaySchedule
+    thursday?: DaySchedule
+    friday?: DaySchedule
+    saturday?: DaySchedule
+    sunday?: DaySchedule
+  }
+  note?: string
+  breakTime?: string
 }
 
 /**
@@ -117,6 +128,7 @@ export interface CreateStoreFormData {
 
   // Operating information
   is_24_hours: boolean
+  business_hours: BusinessHours | null
   gacha_machine_count: string
 
   // Verification
@@ -156,6 +168,7 @@ export interface CreateStoreDto {
 
   // Operating information
   is_24_hours?: boolean
+  business_hours?: BusinessHours | null
   gacha_machine_count?: number
 
   // Verification

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,4 +1,4 @@
-import type { DataSource } from "@/features/store/types/store.types";
+import type { DataSource, BusinessHours } from "@/features/store/types/store.types";
 
 export type ShopType = "gacha" | "figure" | "both";
 export type VerificationStatus = "pending" | "verified" | "rejected";
@@ -26,7 +26,7 @@ export interface Store {
   address_type: AddressType | null;
   latitude: number | null;
   longitude: number | null;
-  business_hours: Record<string, unknown> | null;
+  business_hours: BusinessHours | null;
   is_24_hours: boolean | null;
   gacha_machine_count: number | null;
   main_series: string[] | null;


### PR DESCRIPTION
## 개요

상점 등록 모달에서 영업시간을 상세하게 설정할 수 있는 기능을 추가했습니다. 24시간 영업 또는 요일별 영업시간을 선택할 수 있으며, 요일별로 오픈/마감 시간, 브레이크타임, 비고를 입력할 수 있습니다.

## 주요 변경사항

### 1. 타입 시스템 개선
- **DaySchedule 타입 추가**: 영업/휴무 상태를 명확히 구분
  - `{ closed: true }`: 휴무
  - `{ open: string; close: string }`: 영업 (오픈/마감 시간)
- **BusinessHours 타입 확장**: schedule, note, breakTime 필드 추가

### 2. 새로운 UI 컴포넌트
- **Checkbox 컴포넌트** (`src/components/ui/checkbox.tsx`)
  - shadcn/ui 스타일의 체크박스 컴포넌트
  - Radix UI 기반 접근성 지원
  
- **BusinessHoursInput 컴포넌트** (`src/features/store/components/BusinessHoursInput.tsx`)
  - 요일별 오픈/마감 시간 선택 (30분 단위)
  - 평일/주말 일괄 복사 기능
  - 브레이크타임 입력
  - 비고 입력
  - 251줄의 상세한 영업시간 입력 UI

- **OperatingHoursModal 컴포넌트** (`src/features/store/components/OperatingHoursModal.tsx`)
  - 24시간 영업 옵션
  - BusinessHoursInput 통합
  - 모달 state 동기화 처리

### 3. StoreRegistrationModal 개선
- 영업시간 설정 버튼 추가 (Clock 아이콘)
- 24시간 영업 상태 표시
- `business_hours` 필드를 폼 데이터에 추가
- 24시간 영업 시 `business_hours`를 null로 자동 설정

### 4. 의존성 추가
- `@radix-ui/react-checkbox` (^1.1.2): 접근성을 고려한 체크박스 컴포넌트

## 파일 변경 요약

```
8개 파일 변경, 502줄 추가(+), 31줄 삭제(-)

- package.json / package-lock.json          (의존성 추가)
- src/components/ui/checkbox.tsx            (신규, 28줄)
- src/features/store/components/
  - BusinessHoursInput.tsx                  (신규, 251줄)
  - OperatingHoursModal.tsx                 (신규, 131줄)
  - StoreRegistrationModal.tsx              (수정, 58줄 변경)
- src/features/store/types/store.types.ts   (타입 개선)
- src/types/store.ts                        (타입 수정)
```

## 구현 세부사항

### 영업시간 데이터 구조
```typescript
type DaySchedule = 
  | { closed: true }
  | { open: string; close: string }

interface BusinessHours {
  schedule: {
    monday?: DaySchedule
    tuesday?: DaySchedule
    // ... 나머지 요일
  }
  note?: string
  breakTime?: string
}
```

### 주요 기능
1. **요일별 영업시간 설정**
   - 각 요일별로 오픈/마감 시간 선택 (30분 단위)
   - 체크박스로 영업일 선택
   - 체크 해제 시 자동으로 `{closed: true}` 설정

2. **편의 기능**
   - 평일 일괄 복사: 월~금 동일 시간 적용
   - 주말 일괄 복사: 토~일 동일 시간 적용

3. **24시간 영업**
   - 체크박스 활성화 시 `business_hours: null` 저장
   - `is_24_hours: true` 플래그 설정

## 테스트 계획

### 수동 테스트 체크리스트
- [ ] 상점 등록 모달에서 "영업시간 설정" 버튼 클릭
- [ ] 24시간 영업 체크박스 토글 동작 확인
- [ ] 요일별 영업시간 입력
  - [ ] 요일 체크박스 활성화/비활성화
  - [ ] 오픈/마감 시간 선택 (30분 단위)
  - [ ] 평일 일괄 복사 버튼 동작
  - [ ] 주말 일괄 복사 버튼 동작
- [ ] 브레이크타임 입력
- [ ] 비고 입력
- [ ] 저장 버튼 클릭 시 데이터 정상 반영 확인
- [ ] 취소 버튼 클릭 시 초기값으로 복원 확인
- [ ] 모달 재오픈 시 저장된 값 정상 표시 확인

### 검증 포인트
1. **타입 안정성**: TypeScript strict 모드에서 타입 오류 없음
2. **상태 동기화**: 모달이 열릴 때마다 최신 값으로 동기화
3. **데이터 무결성**: 
   - 24시간 영업 시 business_hours는 null
   - 요일별 영업 시 모든 요일에 명시적 값 설정
   - 체크 안한 요일은 {closed: true}로 자동 설정

## 스크린샷

(추후 UI 스크린샷 추가 예정)

## 관련 이슈

- 상점 등록 기능 개선의 일환
- 실제 운영 정보를 더 정확하게 입력받기 위한 UX 개선

## 기술적 고려사항

### React 19 & React Compiler
- React 19의 새로운 기능 활용
- React Compiler 자동 최적화 적용
- useMemo/useCallback 최소화

### 접근성
- Radix UI 기반 컴포넌트로 키보드 네비게이션 지원
- ARIA 속성 자동 적용

### 성능
- 상태 변경 최소화
- 불필요한 리렌더링 방지
- 모달 열릴 때만 state 동기화

## 향후 개선 사항

- [ ] 영업시간 데이터 시각화 컴포넌트
- [ ] 영업시간 검증 로직 강화 (오픈 < 마감 시간 체크 등)
- [ ] 공휴일 영업시간 설정 기능
- [ ] 임시 휴무 설정 기능

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)