### PR TITLE
feat: Instagram 해시태그 관리 시스템 구현

### DIFF
--- a/docs/database/tables/instagram_credentials.md
+++ b/docs/database/tables/instagram_credentials.md
@@ -1,0 +1,313 @@
+# Instagram Credentials Table Schema
+
+## 개요
+Instagram Graph API 인증 정보를 저장하는 테이블
+
+## 테이블 정보
+- **테이블명**: `instagram_credentials`
+- **스키마**: `public`
+- **설명**: Instagram Access Token 및 Business Account 정보를 암호화하여 저장
+- **접근 방식**: Edge Function을 통한 접근만 허용 (RLS 비활성화)
+- **권한 관리**: super_admin만 업데이트 가능
+
+## 주요 용도
+- Instagram Graph API 호출 시 사용할 Access Token 관리
+- 관리자가 수동으로 발급받은 Access Token을 서버에 저장
+- Edge Function에서 암호화된 토큰을 복호화하여 Instagram API 호출
+
+---
+
+## 스키마
+
+| 컬럼명 | 타입 | 제약조건 | 기본값 | 설명 |
+|--------|------|----------|--------|------|
+| id | uuid | PRIMARY KEY | gen_random_uuid() | 레코드 고유 ID |
+| access_token | text | NOT NULL | - | Instagram Access Token (암호화 저장) |
+| user_id | text | NOT NULL | - | Instagram Business Account ID |
+| token_type | text | NOT NULL | 'user' | 토큰 타입 (user/page) |
+| expires_at | timestamptz | - | null | 토큰 만료 시각 (장기 토큰: 60일) |
+| is_active | boolean | NOT NULL | true | 활성화 여부 |
+| created_at | timestamptz | NOT NULL | now() | 생성 일시 |
+| updated_at | timestamptz | NOT NULL | now() | 수정 일시 |
+| created_by | uuid | FOREIGN KEY | - | 생성자 (admin_users.id) |
+| updated_by | uuid | FOREIGN KEY | - | 수정자 (admin_users.id) |
+
+---
+
+## 외래 키 (Foreign Keys)
+
+| 제약조건명 | 소스 컬럼 | 참조 테이블 | 참조 컬럼 | 설명 |
+|-----------|-----------|------------|----------|------|
+| `instagram_credentials_created_by_fkey` | created_by | admin_users | id | 생성자 |
+| `instagram_credentials_updated_by_fkey` | updated_by | admin_users | id | 수정자 |
+
+---
+
+## 인덱스
+
+```sql
+-- 활성화된 credential 조회 (단일 레코드만 활성화)
+CREATE UNIQUE INDEX idx_instagram_credentials_active
+ON instagram_credentials(is_active)
+WHERE is_active = true;
+```
+
+---
+
+## 트리거
+
+```sql
+-- updated_at 자동 갱신
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON instagram_credentials
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_updated_at();
+```
+
+---
+
+## 제약사항
+
+### 1. 단일 활성 Credential
+- `is_active = true`인 레코드는 **항상 1개만** 존재
+- UNIQUE INDEX를 통해 보장
+- 새 토큰 등록 시 기존 활성 토큰은 자동으로 비활성화
+
+### 2. Access Token 암호화
+- **암호화 방식**: Supabase Vault 또는 환경변수 기반 암호화
+- **복호화 시점**: Edge Function에서 Instagram API 호출 직전
+- **저장 형식**: 암호화된 문자열
+
+### 3. 토큰 만료 관리
+- **장기 토큰**: 60일 만료
+- **만료 알림**: 클라이언트에서 `expires_at` 기준으로 만료 임박 표시
+- **Refresh Token**: 추후 자동 갱신 기능 구현 예정
+
+---
+
+## 사용 예시
+
+### 활성 Credential 조회 (Edge Function)
+```sql
+SELECT
+  access_token,
+  user_id,
+  expires_at
+FROM instagram_credentials
+WHERE is_active = true
+LIMIT 1;
+```
+
+### Credential 업데이트 (Upsert)
+```sql
+-- 기존 활성 credential 비활성화
+UPDATE instagram_credentials
+SET is_active = false
+WHERE is_active = true;
+
+-- 새 credential 추가
+INSERT INTO instagram_credentials (
+  access_token,
+  user_id,
+  token_type,
+  expires_at,
+  created_by
+)
+VALUES (
+  'ENCRYPTED_TOKEN',
+  '17841234567890123',
+  'user',
+  NOW() + INTERVAL '60 days',
+  '관리자_UUID'
+)
+RETURNING *;
+```
+
+### 만료 임박 토큰 확인
+```sql
+SELECT
+  id,
+  expires_at,
+  (expires_at - NOW()) AS remaining_time
+FROM instagram_credentials
+WHERE is_active = true
+AND expires_at < NOW() + INTERVAL '7 days';
+```
+
+---
+
+## Edge Functions
+
+### instagram-credentials-upsert
+**목적**: Access Token 업데이트
+**권한**: super_admin만 가능
+**동작**:
+1. 관리자 인증 및 super_admin 체크
+2. 기존 활성 credential 비활성화
+3. 새 credential 추가 (암호화)
+4. 성공/실패 응답
+
+```typescript
+// Request
+POST /instagram-credentials-upsert
+{
+  "access_token": "IGQW...",
+  "user_id": "17841234567890123",
+  "expires_in": 5184000 // 60일 (초 단위)
+}
+
+// Response
+{
+  "success": true,
+  "credential": {
+    "id": "uuid",
+    "expires_at": "2025-01-18T12:00:00Z",
+    "is_active": true
+  }
+}
+```
+
+### instagram-credentials-get
+**목적**: 현재 활성 credential 정보 조회 (토큰 제외)
+**권한**: admin 이상
+**동작**:
+1. 활성 credential의 메타데이터만 반환
+2. access_token은 반환하지 않음 (보안)
+
+```typescript
+// Response
+{
+  "user_id": "17841234567890123",
+  "expires_at": "2025-01-18T12:00:00Z",
+  "days_remaining": 45,
+  "is_expiring_soon": false
+}
+```
+
+---
+
+## 클라이언트 로직
+
+### Credential 설정 UI
+```typescript
+interface InstagramCredential {
+  access_token: string;
+  user_id: string;
+  expires_in?: number; // 초 단위 (기본: 5184000 = 60일)
+}
+
+async function updateInstagramCredential(credential: InstagramCredential) {
+  const response = await fetch('/instagram-credentials-upsert', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(credential)
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to update credential');
+  }
+
+  return response.json();
+}
+```
+
+### 만료 알림
+```typescript
+function isTokenExpiringSoon(expiresAt: string): boolean {
+  const expires = new Date(expiresAt);
+  const now = new Date();
+  const daysRemaining = (expires.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  return daysRemaining <= 7;
+}
+```
+
+---
+
+## 보안 고려사항
+
+### 1. Access Token 암호화
+**방법 1: Supabase Vault (추천)**
+```sql
+-- 저장 시
+INSERT INTO instagram_credentials (access_token, ...)
+VALUES (
+  vault.create_secret('실제_토큰_값', 'instagram-token'),
+  ...
+);
+
+-- 조회 시 (Edge Function)
+SELECT vault.decrypt_secret(access_token) as decrypted_token
+FROM instagram_credentials
+WHERE is_active = true;
+```
+
+**방법 2: 환경변수 기반 암호화**
+```typescript
+// Edge Function에서
+import { encrypt, decrypt } from './crypto.ts';
+
+// 저장 시
+const encrypted = await encrypt(accessToken, Deno.env.get('ENCRYPTION_KEY'));
+
+// 사용 시
+const decrypted = await decrypt(encryptedToken, Deno.env.get('ENCRYPTION_KEY'));
+```
+
+### 2. 권한 제어
+- **업데이트**: super_admin만 가능
+- **조회**: admin 이상 가능 (메타데이터만)
+- **삭제**: super_admin만 가능
+
+### 3. 감사 로그
+- 모든 credential 업데이트 이력 기록
+- `created_by`, `updated_by`로 추적
+
+---
+
+## Instagram Access Token 발급 방법
+
+### 수동 발급 절차
+1. Meta Developers Console 접속
+2. Facebook 앱 생성 및 Instagram Basic Display API 설정
+3. Instagram Business Account 연결
+4. Access Token 발급 (단기 토큰)
+5. 장기 토큰으로 교환 (60일)
+6. Admin UI에서 토큰 등록
+
+### 토큰 교환 API
+```bash
+# 단기 → 장기 토큰 교환
+curl -X GET "https://graph.facebook.com/v24.0/oauth/access_token?\
+grant_type=fb_exchange_token&\
+client_id={app-id}&\
+client_secret={app-secret}&\
+fb_exchange_token={short-lived-token}"
+```
+
+---
+
+## 향후 개선 사항
+
+### 1. Refresh Token 자동 갱신
+- 만료 7일 전 자동으로 토큰 갱신
+- Cron job 또는 Supabase Edge Function 스케줄러 활용
+
+### 2. 다중 Account 지원
+- 여러 Instagram Business Account 관리
+- Account별 credential 분리
+
+### 3. 토큰 Health Check
+- 주기적으로 토큰 유효성 검증
+- 만료되거나 revoke된 토큰 자동 감지
+
+---
+
+## 최근 변경 사항
+
+### 2025-11-19: 테이블 생성
+- Instagram Access Token 서버 저장 기능 추가
+- 암호화 저장 구조 설계
+- 단일 활성 credential 제약 추가

--- a/docs/database/tables/instagram_hashtags.md
+++ b/docs/database/tables/instagram_hashtags.md
@@ -1,0 +1,237 @@
+# Instagram Hashtags Table Schema
+
+## 개요
+Instagram 해시태그 정보를 관리하는 테이블
+
+## 테이블 정보
+- **테이블명**: `instagram_hashtags`
+- **스키마**: `public`
+- **설명**: Instagram Graph API를 통해 등록된 해시태그 정보 저장
+- **접근 방식**: Edge Function을 통한 접근만 허용 (RLS 비활성화)
+- **권한 관리**: Edge Function의 auth middleware에서 super_admin/admin 권한 체크
+
+## 주요 용도
+- 해시태그 기반 미디어 검색 (recent_media API)
+- 활성화된 해시태그만 필터링하여 유저 서비스/피드 관리에 활용
+- 7일 제한 관리 (Instagram API 정책: 7일 동안 최대 30개 고유 해시태그)
+
+---
+
+## 스키마
+
+| 컬럼명 | 타입 | 제약조건 | 기본값 | 설명 |
+|--------|------|----------|--------|------|
+| id | uuid | PRIMARY KEY | gen_random_uuid() | 해시태그 고유 ID |
+| keyword | text | NOT NULL | - | 해시태그 키워드 (예: "fashion", "travel") |
+| hashtag_id | text | NOT NULL, UNIQUE | - | Instagram Graph API에서 반환된 해시태그 ID |
+| is_active | boolean | NOT NULL | true | 활성화 여부 (true: 활성화, false: 비활성화) |
+| created_at | timestamptz | NOT NULL | now() | 생성 일시 (7일 제한 계산 기준) |
+| updated_at | timestamptz | NOT NULL | now() | 수정 일시 |
+| created_by | uuid | FOREIGN KEY | - | 생성자 (admin_users.id) |
+| updated_by | uuid | FOREIGN KEY | - | 수정자 (admin_users.id) |
+
+---
+
+## 외래 키 (Foreign Keys)
+
+| 제약조건명 | 소스 컬럼 | 참조 테이블 | 참조 컬럼 | 설명 |
+|-----------|-----------|------------|----------|------|
+| `instagram_hashtags_created_by_fkey` | created_by | admin_users | id | 생성자 |
+| `instagram_hashtags_updated_by_fkey` | updated_by | admin_users | id | 수정자 |
+
+---
+
+## 인덱스
+
+```sql
+-- 활성화된 해시태그 조회 최적화
+CREATE INDEX idx_instagram_hashtags_is_active
+ON instagram_hashtags(is_active)
+WHERE is_active = true;
+
+-- 생성일 기준 조회 (7일 제한 체크용)
+CREATE INDEX idx_instagram_hashtags_created_at
+ON instagram_hashtags(created_at DESC);
+
+-- 키워드 검색 최적화
+CREATE INDEX idx_instagram_hashtags_keyword
+ON instagram_hashtags USING gin(keyword gin_trgm_ops);
+```
+
+---
+
+## 트리거
+
+```sql
+-- updated_at 자동 갱신
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON instagram_hashtags
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_updated_at();
+```
+
+---
+
+## 제약사항
+
+### 1. 7일 제한 관리
+- **Instagram API 정책**: 7일 동안 최대 30개의 고유한 해시태그 쿼리 가능
+- `created_at` 기준으로 **클라이언트에서** 7일 경과 여부 표시
+- DB에는 별도 상태 저장하지 않음 (클라이언트 계산)
+
+### 2. 활성화/비활성화
+- `is_active` 필드로 관리
+- 비활성화된 해시태그는 유저 서비스/피드 관리에서 조회 제외
+- 7일 제한과는 독립적으로 관리
+
+### 3. 수정 불가
+- 해시태그 키워드 및 ID는 수정 불가
+- 활성화/비활성화 토글만 가능 (UPDATE)
+
+---
+
+## 사용 예시
+
+### 활성화된 해시태그 조회
+```sql
+SELECT * FROM instagram_hashtags
+WHERE is_active = true
+ORDER BY created_at DESC;
+```
+
+### 7일 이내 등록된 해시태그 조회
+```sql
+SELECT * FROM instagram_hashtags
+WHERE created_at > NOW() - INTERVAL '7 days'
+ORDER BY created_at DESC;
+```
+
+### 활성화된 + 7일 이내 해시태그 개수 확인
+```sql
+SELECT COUNT(*) FROM instagram_hashtags
+WHERE is_active = true
+AND created_at > NOW() - INTERVAL '7 days';
+```
+
+### 해시태그 등록 (Edge Function에서 사용)
+```sql
+INSERT INTO instagram_hashtags (keyword, hashtag_id, created_by)
+VALUES ('fashion', '17843826142345678', '관리자_UUID')
+RETURNING *;
+```
+
+### 활성화/비활성화 토글
+```sql
+UPDATE instagram_hashtags
+SET
+  is_active = NOT is_active,
+  updated_by = '관리자_UUID',
+  updated_at = NOW()
+WHERE id = '해시태그_UUID'
+RETURNING *;
+```
+
+---
+
+## 연관 API
+
+### Instagram Graph API
+
+#### 1. 해시태그 검색
+```
+GET https://graph.facebook.com/v24.0/ig_hashtag_search
+```
+**Parameters:**
+- `user_id`: Instagram Business Account ID
+- `q`: 검색 키워드 (예: "fashion")
+- `access_token`: Instagram Access Token
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "17843826142345678"
+    }
+  ]
+}
+```
+
+#### 2. 최근 미디어 조회 (향후 사용 예정)
+```
+GET https://graph.facebook.com/v24.0/{hashtag_id}/recent_media
+```
+**Parameters:**
+- `user_id`: Instagram Business Account ID
+- `fields`: 조회할 필드 (예: "id,media_type,media_url,permalink")
+- `access_token`: Instagram Access Token
+
+---
+
+## Edge Functions
+
+### 예상 Edge Function 목록
+- `instagram-hashtags-list` - 해시태그 목록 조회 (GET)
+- `instagram-hashtags-create` - 해시태그 등록 (POST)
+- `instagram-hashtags-toggle` - 활성화/비활성화 토글 (PATCH)
+- `instagram-hashtags-delete` - 해시태그 삭제 (DELETE)
+
+---
+
+## 클라이언트 로직
+
+### 7일 경과 여부 계산
+```typescript
+function isExpiredHashtag(createdAt: string): boolean {
+  const created = new Date(createdAt);
+  const now = new Date();
+  const diffInDays = (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24);
+  return diffInDays > 7;
+}
+```
+
+### 등록 가능 개수 확인
+```typescript
+function canAddMoreHashtags(hashtags: InstagramHashtag[]): boolean {
+  const activeWithin7Days = hashtags.filter(
+    (h) => !isExpiredHashtag(h.created_at)
+  );
+  return activeWithin7Days.length < 30;
+}
+```
+
+---
+
+## Migration
+
+마이그레이션 파일: `supabase/migrations/YYYYMMDDHHMMSS_create_instagram_hashtags_table.sql`
+
+---
+
+## 참고사항
+
+### Instagram Credentials 관리
+- **저장 위치**: localStorage (키: `instagram_credentials`)
+- **구조**:
+  ```typescript
+  {
+    access_token: string;
+    user_id: string; // Instagram Business Account ID
+  }
+  ```
+- **Refresh Token**: 추후 개발 예정
+- **현재 방식**: 수동으로 localStorage에 credential 설정 필요
+
+### 보안 고려사항
+1. **Edge Function 권한 체크**: `requireAdmin()` 사용
+2. **RLS 비활성화**: Edge Function을 통해서만 접근
+3. **Access Token**: 클라이언트에서 관리 (향후 서버 저장 고려)
+
+---
+
+## 최근 변경 사항
+
+### 2025-11-19: 테이블 생성
+- Instagram 해시태그 관리 기능 추가
+- 7일/30개 제한 관리 지원
+- 활성화/비활성화 토글 기능

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,60 +1,60 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { AuthStateProvider } from './providers/AuthStateProvider';
-import { ProtectedRoute } from './components/auth/ProtectedRoute';
-import { MenuProtectedRoute } from './components/auth/MenuProtectedRoute';
-import { MainLayout } from './components/layout/MainLayout';
-import { Dashboard } from './pages/Dashboard';
-import { Users } from './pages/Users';
-import { Settings } from './pages/Settings';
-import { Login } from './pages/Login';
-import { SignUp } from './pages/SignUp';
-import { NotFound } from './pages/NotFound';
-import { AdminApprovals } from './pages/AdminApprovals';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthStateProvider } from "./providers/AuthStateProvider";
+import { ProtectedRoute } from "./components/auth/ProtectedRoute";
+import { MenuProtectedRoute } from "./components/auth/MenuProtectedRoute";
+import { MainLayout } from "./components/layout/MainLayout";
+import { Dashboard } from "./pages/Dashboard";
+import { Users } from "./pages/Users";
+import { Settings } from "./pages/Settings";
+import { Login } from "./pages/Login";
+import { SignUp } from "./pages/SignUp";
+import { NotFound } from "./pages/NotFound";
+import { AdminApprovals } from "./pages/AdminApprovals";
 
 // Gacha Shop
-import Shops from './pages/Shops';
-import Tags from './pages/Tags';
-import ShopReviews from './pages/ShopReviews';
+import Shops from "./pages/Shops";
+import Tags from "./pages/Tags";
+import ShopReviews from "./pages/ShopReviews";
 
 // Instagram
-import InstagramHashtags from './pages/InstagramHashtags';
-import InstagramFeeds from './pages/InstagramFeeds';
+import InstagramHashtags from "./pages/InstagramHashtags";
+import InstagramFeeds from "./pages/InstagramFeeds";
 
 // Animation
-import AnimationCharacters from './pages/AnimationCharacters';
+import AnimationCharacters from "./pages/AnimationCharacters";
 
 // Admin
-import AdminUsers from './pages/AdminUsers';
-import AdminPermissions from './pages/AdminPermissions';
-import MenuManagement from './pages/MenuManagement';
+import AdminUsers from "./pages/AdminUsers";
+import AdminPermissions from "./pages/AdminPermissions";
+import MenuManagement from "./pages/MenuManagement";
 
 // Community
-import CommunityPosts from './pages/CommunityPosts';
+import CommunityPosts from "./pages/CommunityPosts";
 
 // Owner
-import OwnerDashboard from './pages/OwnerDashboard';
-import { OwnerStores } from './pages/owner/OwnerStores';
+import OwnerDashboard from "./pages/OwnerDashboard";
+import { OwnerStores } from "./pages/owner/OwnerStores";
 
 // Test
-import TestEdgeFunctions from './pages/TestEdgeFunctions';
+import TestEdgeFunctions from "./pages/TestEdgeFunctions";
 
 function App() {
   return (
     <BrowserRouter>
       <AuthStateProvider>
         <Routes>
-          <Route path='/login' element={<Login />} />
-          <Route path='/signup' element={<SignUp />} />
-          <Route path='/404' element={<NotFound />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<SignUp />} />
+          <Route path="/404" element={<NotFound />} />
           <Route element={<ProtectedRoute />}>
-            <Route path='/' element={<MainLayout />}>
+            <Route path="/" element={<MainLayout />}>
               <Route index element={<Dashboard />} />
 
               {/* Products - Legacy */}
 
               {/* Gacha Shop */}
               <Route
-                path='shops'
+                path="shops"
                 element={
                   <MenuProtectedRoute>
                     <Shops />
@@ -62,7 +62,7 @@ function App() {
                 }
               />
               <Route
-                path='shops/tags'
+                path="shops/tags"
                 element={
                   <MenuProtectedRoute>
                     <Tags />
@@ -70,7 +70,7 @@ function App() {
                 }
               />
               <Route
-                path='shops/reviews'
+                path="shops/reviews"
                 element={
                   <MenuProtectedRoute>
                     <ShopReviews />
@@ -80,7 +80,7 @@ function App() {
 
               {/* Instagram */}
               <Route
-                path='instagram/hashtags'
+                path="instagram/hashtags"
                 element={
                   <MenuProtectedRoute>
                     <InstagramHashtags />
@@ -88,7 +88,7 @@ function App() {
                 }
               />
               <Route
-                path='instagram/feeds'
+                path="instagram/feeds"
                 element={
                   <MenuProtectedRoute>
                     <InstagramFeeds />
@@ -98,7 +98,7 @@ function App() {
 
               {/* Animation */}
               <Route
-                path='animation/characters'
+                path="animation/characters"
                 element={
                   <MenuProtectedRoute>
                     <AnimationCharacters />
@@ -108,7 +108,7 @@ function App() {
 
               {/* Admin */}
               <Route
-                path='admin/users'
+                path="admin/users"
                 element={
                   <MenuProtectedRoute>
                     <AdminUsers />
@@ -116,7 +116,7 @@ function App() {
                 }
               />
               <Route
-                path='admin/permissions'
+                path="admin/permissions"
                 element={
                   <MenuProtectedRoute>
                     <AdminPermissions />
@@ -124,7 +124,7 @@ function App() {
                 }
               />
               <Route
-                path='admin/menus'
+                path="admin/menus"
                 element={
                   <MenuProtectedRoute>
                     <MenuManagement />
@@ -132,7 +132,7 @@ function App() {
                 }
               />
               <Route
-                path='admin-approvals'
+                path="admin-approvals"
                 element={
                   <MenuProtectedRoute>
                     <AdminApprovals />
@@ -142,7 +142,7 @@ function App() {
 
               {/* User */}
               <Route
-                path='users'
+                path="users"
                 element={
                   <MenuProtectedRoute>
                     <Users />
@@ -152,7 +152,7 @@ function App() {
 
               {/* Community */}
               <Route
-                path='community/posts'
+                path="community/posts"
                 element={
                   <MenuProtectedRoute>
                     <CommunityPosts />
@@ -162,7 +162,7 @@ function App() {
 
               {/* Owner */}
               <Route
-                path='owner/dashboard'
+                path="owner/dashboard"
                 element={
                   <MenuProtectedRoute>
                     <OwnerDashboard />
@@ -170,7 +170,7 @@ function App() {
                 }
               />
               <Route
-                path='owner/store'
+                path="owner/store"
                 element={
                   <MenuProtectedRoute>
                     <OwnerStores />
@@ -180,7 +180,7 @@ function App() {
 
               {/* Test */}
               <Route
-                path='test/edge-functions'
+                path="test/edge-functions"
                 element={
                   <MenuProtectedRoute>
                     <TestEdgeFunctions />
@@ -190,7 +190,7 @@ function App() {
 
               {/* Settings */}
               <Route
-                path='settings'
+                path="settings/instagram"
                 element={
                   <MenuProtectedRoute>
                     <Settings />
@@ -201,7 +201,7 @@ function App() {
           </Route>
 
           {/* Catch all - 404 */}
-          <Route path='*' element={<NotFound />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </AuthStateProvider>
     </BrowserRouter>

--- a/src/components/admin/MenuFormDialog.tsx
+++ b/src/components/admin/MenuFormDialog.tsx
@@ -60,8 +60,6 @@ export function MenuFormDialog({
   const {
     register,
     handleSubmit,
-    setValue,
-    watch,
     reset,
     control,
     formState: { errors },
@@ -77,8 +75,6 @@ export function MenuFormDialog({
       is_active: true,
     },
   });
-
-  const isActive = watch("is_active");
 
   // Dialog 열릴 때 폼 초기화
   useEffect(() => {
@@ -138,9 +134,12 @@ export function MenuFormDialog({
       code: data.code,
       name: data.name,
       description: data.description || undefined,
-      parent_id: data.parent_id && data.parent_id !== "none" ? data.parent_id : undefined,
-      path: data.path || undefined,
-      icon: data.icon || undefined,
+      parent_id:
+        data.parent_id && data.parent_id !== "none"
+          ? data.parent_id
+          : undefined,
+      path: data.path ? data.path : null,
+      icon: data.icon ? data.icon : null,
       display_order: data.display_order,
       is_active: data.is_active,
     };
@@ -233,10 +232,7 @@ export function MenuFormDialog({
                 name="parent_id"
                 control={control}
                 render={({ field }) => (
-                  <Select
-                    value={field.value}
-                    onValueChange={field.onChange}
-                  >
+                  <Select value={field.value} onValueChange={field.onChange}>
                     <SelectTrigger id="parent_id">
                       <SelectValue placeholder="없음 (최상위 메뉴)" />
                     </SelectTrigger>
@@ -302,12 +298,16 @@ export function MenuFormDialog({
 
           {/* 활성 상태 */}
           <div className="flex items-center space-x-2">
-            <Checkbox
-              id="is_active"
-              checked={isActive}
-              onCheckedChange={(checked) =>
-                setValue("is_active", checked as boolean)
-              }
+            <Controller
+              name="is_active"
+              control={control}
+              render={({ field }) => (
+                <Checkbox
+                  id="is_active"
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              )}
             />
             <Label
               htmlFor="is_active"

--- a/src/components/instagram/AddHashtagDialog.tsx
+++ b/src/components/instagram/AddHashtagDialog.tsx
@@ -1,0 +1,134 @@
+/**
+ * AddHashtagDialog Component
+ * Instagram 해시태그 추가 모달
+ */
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { InstagramService } from "@/services/instagram.service";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { AlertCircle, Hash, Loader2 } from "lucide-react";
+
+interface AddHashtagDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function AddHashtagDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: AddHashtagDialogProps) {
+  const [keyword, setKeyword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const searchMutation = useMutation({
+    mutationFn: (keyword: string) => InstagramService.searchHashtag(keyword),
+    onSuccess: (data) => {
+      console.log(data);
+      onSuccess();
+      onOpenChange(false);
+      setKeyword("");
+      setError(null);
+    },
+    onError: (error: Error) => {
+      setError(error.message || "해시태그 검색에 실패했습니다.");
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedKeyword = keyword.trim();
+
+    if (!trimmedKeyword) {
+      setError("키워드를 입력해주세요.");
+      return;
+    }
+
+    searchMutation.mutate(trimmedKeyword);
+  };
+
+  const handleClose = () => {
+    if (!searchMutation.isPending) {
+      onOpenChange(false);
+      setKeyword("");
+      setError(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Instagram 해시태그 추가</DialogTitle>
+          <DialogDescription>
+            Instagram Graph API를 통해 해시태그를 검색하고 등록합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="keyword">해시태그 키워드</Label>
+            <div className="relative">
+              <Hash className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                id="keyword"
+                type="text"
+                placeholder="예: fashion, travel"
+                value={keyword}
+                onChange={(e) => setKeyword(e.target.value)}
+                disabled={searchMutation.isPending}
+                className="pl-10"
+                autoFocus
+              />
+            </div>
+            <p className="text-sm text-gray-500">
+              '#' 기호 없이 키워드만 입력하세요.
+            </p>
+          </div>
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-md p-3 flex items-start gap-2">
+              <AlertCircle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-red-600">{error}</p>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={searchMutation.isPending}
+            >
+              취소
+            </Button>
+            <Button type="submit" disabled={searchMutation.isPending}>
+              {searchMutation.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  등록 중...
+                </>
+              ) : (
+                <>등록</>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/instagram/CredentialStatus.tsx
+++ b/src/components/instagram/CredentialStatus.tsx
@@ -1,0 +1,84 @@
+/**
+ * CredentialStatus Component
+ * Instagram Credential 정보 표시
+ */
+
+import type { InstagramCredential } from "@/services/instagram.service";
+import { AlertCircle, CheckCircle, Clock } from "lucide-react";
+
+interface CredentialStatusProps {
+  credential: InstagramCredential;
+}
+
+export function CredentialStatus({ credential }: CredentialStatusProps) {
+  const { days_remaining, is_expiring_soon, expires_at } = credential;
+
+  const isExpired = days_remaining <= 0;
+
+  return (
+    <div
+      className={`border rounded-md p-4 ${
+        isExpired
+          ? "bg-red-50 border-red-200"
+          : is_expiring_soon
+          ? "bg-yellow-50 border-yellow-200"
+          : "bg-green-50 border-green-200"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        {isExpired ? (
+          <AlertCircle className="h-5 w-5 text-red-600 mt-0.5" />
+        ) : is_expiring_soon ? (
+          <Clock className="h-5 w-5 text-yellow-600 mt-0.5" />
+        ) : (
+          <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
+        )}
+        <div className="flex-1">
+          <h3
+            className={`font-semibold mb-1 ${
+              isExpired
+                ? "text-red-800"
+                : is_expiring_soon
+                ? "text-yellow-800"
+                : "text-green-800"
+            }`}
+          >
+            {isExpired
+              ? "Access Token 만료됨"
+              : is_expiring_soon
+              ? "Access Token 만료 임박"
+              : "Access Token 정상"}
+          </h3>
+          <div
+            className={`text-sm space-y-1 ${
+              isExpired
+                ? "text-red-600"
+                : is_expiring_soon
+                ? "text-yellow-600"
+                : "text-green-600"
+            }`}
+          >
+            <p>
+              <strong>만료까지:</strong> {days_remaining}일
+            </p>
+            <p>
+              <strong>만료일:</strong>{" "}
+              {new Date(expires_at).toLocaleString("ko-KR")}
+            </p>
+          </div>
+          {(isExpired || is_expiring_soon) && (
+            <p
+              className={`mt-2 text-sm ${
+                isExpired ? "text-red-700" : "text-yellow-700"
+              }`}
+            >
+              {isExpired
+                ? "Access Token이 만료되었습니다. 설정 페이지에서 새 토큰을 등록해주세요."
+                : "Access Token이 곧 만료됩니다. 설정 페이지에서 새 토큰을 등록해주세요."}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/instagram/HashtagsTable.tsx
+++ b/src/components/instagram/HashtagsTable.tsx
@@ -1,0 +1,146 @@
+/**
+ * HashtagsTable Component
+ * Instagram 해시태그 목록 테이블
+ */
+
+import {
+  InstagramService,
+  type InstagramHashtag,
+} from "@/services/instagram.service";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Hash, Calendar, Clock, ToggleLeft, ToggleRight } from "lucide-react";
+
+interface HashtagsTableProps {
+  hashtags: InstagramHashtag[];
+  onToggle: (hashtag: InstagramHashtag) => void;
+  isToggling: boolean;
+}
+
+export function HashtagsTable({
+  hashtags,
+  onToggle,
+  isToggling,
+}: HashtagsTableProps) {
+  console.log("hashtags", hashtags);
+
+  if (hashtags.length === 0) {
+    return (
+      <div className="border rounded-md p-8 text-center text-gray-500">
+        <Hash className="h-12 w-12 mx-auto mb-3 opacity-50" />
+        <p className="font-medium">등록된 해시태그가 없습니다</p>
+        <p className="text-sm mt-1">
+          "해시태그 추가" 버튼을 클릭하여 새 해시태그를 등록하세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded-md overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[200px]">키워드</TableHead>
+            <TableHead>해시태그 ID</TableHead>
+            <TableHead className="w-[120px]">상태</TableHead>
+            <TableHead className="w-[150px]">7일 경과</TableHead>
+            <TableHead className="w-[180px]">생성일</TableHead>
+            <TableHead className="w-[100px] text-right">작업</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {hashtags.map((hashtag) => {
+            const isExpired = InstagramService.isExpiredHashtag(
+              hashtag.created_at
+            );
+            const createdDate = new Date(hashtag.created_at);
+            const now = new Date();
+            const diffInDays = Math.floor(
+              (now.getTime() - createdDate.getTime()) / (1000 * 60 * 60 * 24)
+            );
+
+            return (
+              <TableRow key={hashtag.id}>
+                <TableCell className="font-medium">
+                  <div className="flex items-center gap-2">
+                    <Hash className="h-4 w-4 text-gray-400" />
+                    {hashtag.keyword}
+                  </div>
+                </TableCell>
+                <TableCell className="font-mono text-sm text-gray-600">
+                  {hashtag.hashtag_id}
+                </TableCell>
+                <TableCell>
+                  {hashtag.is_active ? (
+                    <Badge variant="default" className="bg-green-600">
+                      활성화
+                    </Badge>
+                  ) : (
+                    <Badge variant="neutral">비활성화</Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {isExpired ? (
+                    <Badge
+                      variant="outline"
+                      className="border-red-300 text-red-600"
+                    >
+                      <Clock className="h-3 w-3 mr-1" />
+                      만료됨 ({diffInDays}일)
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="border-blue-300 text-blue-600"
+                    >
+                      <Calendar className="h-3 w-3 mr-1" />
+                      {diffInDays}일 경과
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm text-gray-600">
+                  {createdDate.toLocaleString("ko-KR", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onToggle(hashtag)}
+                    disabled={isToggling}
+                  >
+                    {hashtag.is_active ? (
+                      <>
+                        <ToggleRight className="h-4 w-4 mr-1" />
+                        비활성화
+                      </>
+                    ) : (
+                      <>
+                        <ToggleLeft className="h-4 w-4 mr-1" />
+                        활성화
+                      </>
+                    )}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/layout/GNB.tsx
+++ b/src/components/layout/GNB.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
+import { clearInstagramCredentials } from '@/lib/instagram-storage';
 
 export function GNB() {
   const { user, signOut } = useAuth();
@@ -7,6 +8,7 @@ export function GNB() {
   const handleLogout = async () => {
     try {
       await signOut();
+      clearInstagramCredentials();
     } catch (error) {
       console.error('로그아웃 실패:', error);
     }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useState, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
 import {
   LayoutDashboard,
   Store,
@@ -7,16 +7,18 @@ import {
   Briefcase,
   ChevronDown,
   type LucideIcon,
-} from 'lucide-react';
-import * as LucideIcons from 'lucide-react';
+  Settings,
+  Instagram,
+} from "lucide-react";
+import * as LucideIcons from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from '@/components/ui/collapsible';
-import { useAuth } from '@/hooks/useAuth';
-import { AdminApprovalService } from '@/services/admin-approval.service';
-import { MenuService, type MenuWithChildren } from '@/services/menu.service';
+} from "@/components/ui/collapsible";
+import { useAuth } from "@/hooks/useAuth";
+import { AdminApprovalService } from "@/services/admin-approval.service";
+import { MenuService, type MenuWithChildren } from "@/services/menu.service";
 
 interface SubMenuItem {
   path: string;
@@ -34,37 +36,37 @@ interface MenuItem {
 
 const baseMenuItems: MenuItem[] = [
   {
-    label: '대시보드',
+    label: "대시보드",
     icon: LayoutDashboard,
-    path: '/',
+    path: "/",
   },
   {
-    label: '가챠 샵',
+    label: "가챠 샵",
     icon: Store,
     subItems: [
-      { path: '/shops', label: '샵 관리' },
-      { path: '/shops/tags', label: '샵 태그 관리' },
-      { path: '/shops/reviews', label: '샵 리뷰 관리' },
+      { path: "/shops", label: "샵 관리" },
+      { path: "/shops/tags", label: "샵 태그 관리" },
+      { path: "/shops/reviews", label: "샵 리뷰 관리" },
     ],
   },
-  // {
-  //   label: "인스타그램",
-  //   icon: Instagram,
-  //   subItems: [
-  //     { path: "/instagram/hashtags", label: "해시태그 관리" },
-  //     { path: "/instagram/feeds", label: "피드 관리" },
-  //   ],
-  // },
+  {
+    label: "인스타그램",
+    icon: Instagram,
+    subItems: [
+      { path: "/instagram/hashtags", label: "해시태그 관리" },
+      { path: "/instagram/feeds", label: "피드 관리" },
+    ],
+  },
   // {
   //   label: "애니메이션",
   //   icon: Sparkles,
   //   subItems: [{ path: "/animation/characters", label: "캐릭터 관리" }],
   // },
   {
-    label: '어드민',
+    label: "어드민",
     icon: Shield,
     subItems: [
-      { path: '/admin/users', label: '어드민 유저 관리' },
+      { path: "/admin/users", label: "어드민 유저 관리" },
       // { path: "/admin/permissions", label: "어드민 메뉴 권한 관리" },
     ],
   },
@@ -79,18 +81,18 @@ const baseMenuItems: MenuItem[] = [
   //   subItems: [{ path: "/community/posts", label: "게시글 관리" }],
   // },
   {
-    label: '사장님',
+    label: "사장님",
     icon: Briefcase,
     subItems: [
-      { path: '/owner/dashboard', label: '사장님 대시보드' },
-      { path: '/owner/store', label: '매장별 관리' },
+      { path: "/owner/dashboard", label: "사장님 대시보드" },
+      { path: "/owner/store", label: "매장별 관리" },
     ],
   },
-  // {
-  //   label: "설정 및 API",
-  //   icon: Settings,
-  //   path: "/settings",
-  // },
+  {
+    label: "설정",
+    icon: Settings,
+    subItems: [{ path: "/settings/instagram", label: "인스타그램 키" }],
+  },
 ];
 
 export function Sidebar() {
@@ -106,7 +108,7 @@ export function Sidebar() {
     loadMenus();
 
     // Load pending count if user is super_admin
-    if (user?.role === 'super_admin') {
+    if (user?.role === "super_admin") {
       loadPendingCount();
 
       // Refresh every 30 seconds
@@ -122,11 +124,11 @@ export function Sidebar() {
       const convertedMenuItems = convertMenusToMenuItems(menus);
       setMenuItems(convertedMenuItems);
     } catch (error) {
-      console.error('Failed to load menus:', error);
+      console.error("Failed to load menus:", error);
       // Fallback to base menu items on error
       setMenuItems(
         baseMenuItems.filter((item) => {
-          if (item.requiresSuperAdmin && user?.role !== 'super_admin') {
+          if (item.requiresSuperAdmin && user?.role !== "super_admin") {
             return false;
           }
           return true;
@@ -164,7 +166,7 @@ export function Sidebar() {
       // If has children, convert them to subItems
       if (menu.children && menu.children.length > 0) {
         menuItem.subItems = menu.children.map((child) => ({
-          path: child.path || '#',
+          path: child.path || "#",
           label: child.name,
         }));
       }
@@ -188,24 +190,24 @@ export function Sidebar() {
 
   // Add badge count for admin approvals menu
   const menuItemsWithBadge = menuItems.map((item) => {
-    if (item.path === '/admin-approvals' && pendingCount > 0) {
+    if (item.path === "/admin-approvals" && pendingCount > 0) {
       return { ...item, badge: pendingCount };
     }
     return item;
   });
 
   return (
-    <aside className='w-64 bg-gray-900 text-white fixed left-0 top-0 bottom-0 z-20'>
-      <div className='h-16 flex items-center justify-center border-b border-gray-800'>
-        <h2 className='text-lg font-bold'>GACHA STORE</h2>
+    <aside className="w-64 bg-gray-900 text-white fixed left-0 top-0 bottom-0 z-20">
+      <div className="h-16 flex items-center justify-center border-b border-gray-800">
+        <h2 className="text-lg font-bold">GACHA STORE</h2>
       </div>
-      <nav className='p-4'>
+      <nav className="p-4">
         {isLoadingMenus ? (
-          <div className='flex items-center justify-center py-8'>
-            <div className='text-gray-400 text-sm'>메뉴 로딩 중...</div>
+          <div className="flex items-center justify-center py-8">
+            <div className="text-gray-400 text-sm">메뉴 로딩 중...</div>
           </div>
         ) : (
-          <ul className='space-y-1'>
+          <ul className="space-y-1">
             {menuItemsWithBadge.map((item) => {
               const Icon = item.icon;
               const hasSubItems = item.subItems && item.subItems.length > 0;
@@ -221,14 +223,14 @@ export function Sidebar() {
                       to={item.path}
                       className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
                         isActive
-                          ? 'bg-primary text-white'
-                          : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                          ? "bg-primary text-white"
+                          : "text-gray-300 hover:bg-gray-800 hover:text-white"
                       }`}
                     >
-                      <Icon className='w-5 h-5' />
-                      <span className='font-medium'>{item.label}</span>
+                      <Icon className="w-5 h-5" />
+                      <span className="font-medium">{item.label}</span>
                       {item.badge && item.badge > 0 && (
-                        <span className='ml-auto bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full min-w-[20px] text-center'>
+                        <span className="ml-auto bg-red-500 text-white text-xs font-bold px-2 py-1 rounded-full min-w-[20px] text-center">
                           {item.badge}
                         </span>
                       )}
@@ -243,27 +245,27 @@ export function Sidebar() {
                     open={isOpen}
                     onOpenChange={() => toggleItem(item.label)}
                   >
-                    <CollapsibleTrigger className='w-full'>
+                    <CollapsibleTrigger className="w-full">
                       <div
                         className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
                           isActive
-                            ? 'bg-gray-800 text-white'
-                            : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+                            ? "bg-gray-800 text-white"
+                            : "text-gray-300 hover:bg-gray-800 hover:text-white"
                         }`}
                       >
-                        <Icon className='w-5 h-5' />
-                        <span className='font-medium flex-1 text-left'>
+                        <Icon className="w-5 h-5" />
+                        <span className="font-medium flex-1 text-left">
                           {item.label}
                         </span>
                         <ChevronDown
                           className={`w-4 h-4 transition-transform ${
-                            isOpen ? 'rotate-180' : ''
+                            isOpen ? "rotate-180" : ""
                           }`}
                         />
                       </div>
                     </CollapsibleTrigger>
                     <CollapsibleContent>
-                      <ul className='mt-1 space-y-1'>
+                      <ul className="mt-1 space-y-1">
                         {item.subItems?.map((subItem) => {
                           const isSubActive =
                             location.pathname === subItem.path;
@@ -273,8 +275,8 @@ export function Sidebar() {
                                 to={subItem.path}
                                 className={`flex items-center gap-3 pl-12 pr-4 py-2.5 rounded-lg transition-colors text-sm ${
                                   isSubActive
-                                    ? 'bg-primary text-white font-medium'
-                                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                                    ? "bg-primary text-white font-medium"
+                                    : "text-gray-400 hover:bg-gray-800 hover:text-white"
                                 }`}
                               >
                                 {subItem.label}

--- a/src/features/store/components/StoreListTable.tsx
+++ b/src/features/store/components/StoreListTable.tsx
@@ -1,17 +1,17 @@
-'use no memo';
+"use no memo";
 
-import { useState } from 'react';
+import { useState } from "react";
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
   type ColumnDef,
-} from '@tanstack/react-table';
-import { Trash2 } from 'lucide-react';
-import { useStores, useDeleteStore } from '@/hooks/useStores';
-import type { Store, ShopType, VerificationStatus } from '@/types/store';
-import { formatShopTypes } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
+} from "@tanstack/react-table";
+import { Trash2 } from "lucide-react";
+import { useStores, useDeleteStore } from "@/hooks/useStores";
+import type { Store, ShopType, VerificationStatus } from "@/types/store";
+import { formatShopTypes } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -19,7 +19,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
+} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -27,8 +27,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table';
-import { StoreRegistrationModal } from './StoreRegistrationModal';
+} from "@/components/ui/table";
+import { StoreRegistrationModal } from "./StoreRegistrationModal";
 
 interface ColumnsProps {
   onDeleteClick: (store: Store) => void;
@@ -41,52 +41,56 @@ const createColumns = ({
   onEditClick,
 }: ColumnsProps): ColumnDef<Store>[] => [
   {
-    accessorKey: 'name',
-    header: '매장명',
+    accessorKey: "name",
+    header: "매장명",
     cell: ({ row }) => (
       <button
         onClick={() => onEditClick(row.original)}
-        className='font-medium text-blue-600 hover:text-blue-800 hover:underline cursor-pointer'
+        className="font-medium text-blue-600 hover:text-blue-800 hover:underline cursor-pointer"
       >
-        {row.getValue('name')}
+        {row.getValue("name")}
       </button>
     ),
   },
   {
-    accessorKey: 'shop_type',
-    header: '매장 유형',
+    accessorKey: "shop_type",
+    header: "매장 유형",
     cell: ({ row }) => {
-      const types = row.getValue('shop_type') as ShopType;
+      const types = row.getValue("shop_type") as ShopType;
       return <span>{formatShopTypes(types)}</span>;
     },
   },
   {
-    accessorKey: 'address_full',
-    header: '주소',
+    accessorKey: "address_full",
+    header: "주소",
     cell: ({ row }) => {
       const addressType = row.original.address_type;
       const address =
-        (addressType === 'J'
+        (addressType === "J"
           ? row.original.jibun_address
           : row.original.road_address) || row.original.road_address;
-      const totalAddress = `${address} ${row.original.detail_address || ''}`;
-      return <div className='max-w-xs truncate' title={totalAddress}>{totalAddress}</div>;
+      const totalAddress = `${address} ${row.original.detail_address || ""}`;
+      return (
+        <div className="max-w-xs truncate" title={totalAddress}>
+          {totalAddress}
+        </div>
+      );
     },
   },
   {
-    accessorKey: 'verification_status',
-    header: '검증 상태',
+    accessorKey: "verification_status",
+    header: "검증 상태",
     cell: ({ row }) => {
-      const status = row.getValue('verification_status') as VerificationStatus;
+      const status = row.getValue("verification_status") as VerificationStatus;
       const statusStyles: Record<VerificationStatus, string> = {
-        pending: 'bg-yellow-100 text-yellow-800',
-        verified: 'bg-green-100 text-green-800',
-        rejected: 'bg-red-100 text-red-800',
+        pending: "bg-yellow-100 text-yellow-800",
+        verified: "bg-green-100 text-green-800",
+        rejected: "bg-red-100 text-red-800",
       };
       const statusLabels: Record<VerificationStatus, string> = {
-        pending: '대기중',
-        verified: '검증완료',
-        rejected: '거부됨',
+        pending: "대기중",
+        verified: "검증완료",
+        rejected: "거부됨",
       };
       return (
         <span
@@ -98,32 +102,32 @@ const createColumns = ({
     },
   },
   {
-    accessorKey: 'gacha_machine_count',
-    header: '기기 수',
+    accessorKey: "gacha_machine_count",
+    header: "기기 수",
     cell: ({ row }) => {
-      const count = row.getValue('gacha_machine_count') as number | null;
-      return <span>{count ?? '-'}</span>;
+      const count = row.getValue("gacha_machine_count") as number | null;
+      return <span>{count ?? "-"}</span>;
     },
   },
   {
-    accessorKey: 'created_at',
-    header: '등록일',
+    accessorKey: "created_at",
+    header: "등록일",
     cell: ({ row }) => {
-      const date = new Date(row.getValue('created_at'));
-      return <span>{date.toLocaleDateString('ko-KR')}</span>;
+      const date = new Date(row.getValue("created_at"));
+      return <span>{date.toLocaleDateString("ko-KR")}</span>;
     },
   },
   {
-    id: 'actions',
-    header: '액션',
+    id: "actions",
+    header: "액션",
     cell: ({ row }) => (
       <Button
-        variant='ghost'
-        size='icon-sm'
+        variant="ghost"
+        size="icon-sm"
         onClick={() => onDeleteClick(row.original)}
-        className='text-red-600 hover:text-red-700 hover:bg-red-50'
+        className="text-red-600 hover:text-red-700 hover:bg-red-50"
       >
-        <Trash2 className='h-4 w-4' />
+        <Trash2 className="h-4 w-4" />
       </Button>
     ),
   },
@@ -166,7 +170,7 @@ export function StoreListTable() {
       setDeleteDialogOpen(false);
       setStoreToDelete(null);
     } catch (error) {
-      console.error('Failed to delete store:', error);
+      console.error("Failed to delete store:", error);
     }
   };
 
@@ -194,10 +198,10 @@ export function StoreListTable() {
 
   if (error) {
     return (
-      <div className='flex items-center justify-center h-64'>
-        <div className='text-red-600'>
-          에러가 발생했습니다:{' '}
-          {error instanceof Error ? error.message : '알 수 없는 에러'}
+      <div className="flex items-center justify-center h-64">
+        <div className="text-red-600">
+          에러가 발생했습니다:{" "}
+          {error instanceof Error ? error.message : "알 수 없는 에러"}
         </div>
       </div>
     );
@@ -205,8 +209,8 @@ export function StoreListTable() {
 
   if (isLoading) {
     return (
-      <div className='flex items-center justify-center h-64'>
-        <div className='text-gray-500'>로딩 중...</div>
+      <div className="flex items-center justify-center h-64">
+        <div className="text-gray-500">로딩 중...</div>
       </div>
     );
   }
@@ -225,7 +229,7 @@ export function StoreListTable() {
         }}
       />
 
-      <div className='space-y-4'>
+      <div className="space-y-4">
         {/* Table with horizontal scroll */}
         <Table>
           <TableHeader>
@@ -262,7 +266,7 @@ export function StoreListTable() {
               <TableRow>
                 <TableCell
                   colSpan={columns.length}
-                  className='h-24 text-center'
+                  className="h-24 text-center"
                 >
                   데이터가 없습니다.
                 </TableCell>
@@ -272,9 +276,9 @@ export function StoreListTable() {
         </Table>
 
         {/* Pagination */}
-        <div className='flex items-center justify-between'>
-          <div className='text-sm text-gray-700'>
-            전체 {data?.pagination.total ?? 0}개 중{' '}
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-gray-700">
+            전체 {data?.pagination.total ?? 0}개 중{" "}
             {pagination.pageIndex * pagination.pageSize + 1}-
             {Math.min(
               (pagination.pageIndex + 1) * pagination.pageSize,
@@ -282,16 +286,16 @@ export function StoreListTable() {
             )}
             개 표시
           </div>
-          <div className='flex gap-2'>
+          <div className="flex gap-2">
             <Button
-              variant='outline'
+              variant="outline"
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
             >
               이전
             </Button>
             <Button
-              variant='outline'
+              variant="outline"
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
             >
@@ -314,18 +318,18 @@ export function StoreListTable() {
           </DialogHeader>
           <DialogFooter>
             <Button
-              variant='outline'
+              variant="outline"
               onClick={handleDeleteCancel}
               disabled={deleteStore.isPending}
             >
               취소
             </Button>
             <Button
-              variant='destructive'
+              variant="destructive"
               onClick={handleDeleteConfirm}
               disabled={deleteStore.isPending}
             >
-              {deleteStore.isPending ? '삭제 중...' : '삭제'}
+              {deleteStore.isPending ? "삭제 중..." : "삭제"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/lib/instagram-storage.ts
+++ b/src/lib/instagram-storage.ts
@@ -1,0 +1,56 @@
+/**
+ * Instagram credentials storage utility
+ * Manages Instagram user ID and access token in localStorage
+ */
+
+export interface InstagramCredentials {
+  user_id: string;
+  access_token: string;
+}
+
+const STORAGE_KEY = 'instagram_credentials';
+
+/**
+ * Get Instagram credentials from localStorage
+ * Falls back to environment variables if not found in localStorage
+ */
+export function getInstagramCredentials(): InstagramCredentials {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (error) {
+    console.error('Failed to parse Instagram credentials from localStorage:', error);
+  }
+
+  // Fallback to environment variables
+  return {
+    user_id: import.meta.env.VITE_INSTAGRAM_USER_ID || '',
+    access_token: import.meta.env.VITE_INSTAGRAM_ACCESS_TOKEN || '',
+  };
+}
+
+/**
+ * Save Instagram credentials to localStorage
+ */
+export function saveInstagramCredentials(credentials: InstagramCredentials): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(credentials));
+  } catch (error) {
+    console.error('Failed to save Instagram credentials to localStorage:', error);
+    throw error;
+  }
+}
+
+/**
+ * Clear Instagram credentials from localStorage
+ * Call this on logout
+ */
+export function clearInstagramCredentials(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear Instagram credentials from localStorage:', error);
+  }
+}

--- a/src/pages/InstagramHashtags.tsx
+++ b/src/pages/InstagramHashtags.tsx
@@ -1,8 +1,203 @@
+/**
+ * Instagram Hashtags Page
+ * Instagram 해시태그 관리 페이지
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  InstagramService,
+  type InstagramHashtag,
+} from "@/services/instagram.service";
+import { Button } from "@/components/ui/button";
+import { Plus, RefreshCw } from "lucide-react";
+import { AddHashtagDialog } from "@/components/instagram/AddHashtagDialog";
+import { HashtagsTable } from "@/components/instagram/HashtagsTable";
+
 export default function InstagramHashtags() {
+  const queryClient = useQueryClient();
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  // 해시태그 목록 조회
+  const {
+    data: hashtagsData,
+    isLoading: isLoadingHashtags,
+    error: hashtagsError,
+    refetch: refetchHashtags,
+  } = useQuery({
+    queryKey: ["instagram-hashtags"],
+    queryFn: () => InstagramService.listHashtags(),
+    select: (data) => data.data,
+  });
+
+  // Credential 정보 조회
+  // const {
+  //   data: credential,
+  //   isLoading: isLoadingCredential,
+  //   error: credentialError,
+  // } = useQuery({
+  //   queryKey: ["instagram-credential"],
+  //   queryFn: () => InstagramService.getCredential(),
+  //   retry: 1,
+  // });
+
+  // 해시태그 토글 mutation
+  const toggleMutation = useMutation({
+    mutationFn: (hashtagId: string) =>
+      InstagramService.toggleHashtag(hashtagId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["instagram-hashtags"] });
+      alert(`Hashtag ${data.is_active ? "activated" : "deactivated"} successfully`);
+    },
+    onError: (error: Error) => {
+      alert(error.message || "Failed to toggle hashtag");
+    },
+  });
+
+  const handleToggle = (hashtag: InstagramHashtag) => {
+    toggleMutation.mutate(hashtag.id);
+  };
+
+  const handleRefresh = () => {
+    refetchHashtags();
+  };
+
+  // 로딩 상태
+  if (isLoadingHashtags) {
+    return (
+      <div className="p-6">
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4 text-blue-600" />
+            <p className="text-gray-600">Loading...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (hashtagsError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-md p-4">
+          <h3 className="text-red-800 font-semibold mb-2">Error</h3>
+          <p className="text-red-600">
+            {hashtagsError.message || "Failed to load hashtags"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const hashtags = hashtagsData?.hashtags || [];
+  const limitInfo = hashtagsData?.limit_info;
+  const canAddMore = limitInfo && limitInfo.remaining > 0;
+
   return (
-    <div>
-      <h1 className='text-2xl font-bold mb-4'>해시태그 관리</h1>
-      <p className='text-gray-600'>인스타그램 해시태그를 관리하는 페이지입니다.</p>
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold mb-2">Instagram 해시태그 관리</h1>
+          <p className="text-gray-600">
+            Instagram Graph API를 통해 해시태그를 등록하고 관리합니다.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={handleRefresh}
+            disabled={isLoadingHashtags}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            새로고침
+          </Button>
+          <Button
+            onClick={() => setIsAddDialogOpen(true)}
+            disabled={!canAddMore}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            해시태그 추가
+          </Button>
+        </div>
+      </div>
+
+      {/* Credential Status */}
+      {/* {credentialError ? (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4">
+          <h3 className="text-yellow-800 font-semibold mb-2">
+            Instagram Credential 미설정
+          </h3>
+          <p className="text-yellow-600 mb-3">
+            Instagram API를 사용하려면 먼저 Access Token을 설정해야 합니다.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => (window.location.href = "/settings")}
+          >
+            설정 페이지로 이동
+          </Button>
+        </div>
+      ) : credential ? (
+        <CredentialStatus credential={credential} />
+      ) : null} */}
+
+      {/* Limit Info */}
+      {limitInfo && (
+        <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
+          <h3 className="text-blue-800 font-semibold mb-2">
+            Instagram API 제한사항
+          </h3>
+          <div className="grid grid-cols-3 gap-4 text-sm">
+            <div>
+              <p className="text-gray-600">7일 이내 등록된 해시태그</p>
+              <p className="text-2xl font-bold text-blue-600">
+                {limitInfo.current_count}
+                <span className="text-sm text-gray-500">
+                  {" "}
+                  / {limitInfo.max_hashtags_per_7_days}
+                </span>
+              </p>
+            </div>
+            <div>
+              <p className="text-gray-600">추가 가능 개수</p>
+              <p className="text-2xl font-bold text-green-600">
+                {limitInfo.remaining}
+              </p>
+            </div>
+            <div>
+              <p className="text-gray-600">전체 해시태그</p>
+              <p className="text-2xl font-bold text-gray-700">
+                {hashtagsData?.total || 0}
+              </p>
+            </div>
+          </div>
+          {!canAddMore && (
+            <p className="text-red-600 mt-3 text-sm">
+              7일 이내 등록된 해시태그가 30개에 도달했습니다. 새 해시태그를
+              추가하려면 기존 해시태그가 7일이 지날 때까지 기다려주세요.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Hashtags Table */}
+      <HashtagsTable
+        hashtags={hashtags}
+        onToggle={handleToggle}
+        isToggling={toggleMutation.isPending}
+      />
+
+      {/* Add Hashtag Dialog */}
+      <AddHashtagDialog
+        open={isAddDialogOpen}
+        onOpenChange={setIsAddDialogOpen}
+        onSuccess={() => {
+          queryClient.invalidateQueries({ queryKey: ["instagram-hashtags"] });
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,9 +1,202 @@
+/**
+ * Settings Page
+ * Instagram Credentials 설정 페이지 (서버 저장 방식)
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { InstagramService } from "@/services/instagram.service";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { AlertCircle, CheckCircle, Key, Loader2, User } from "lucide-react";
+import { CredentialStatus } from "@/components/instagram/CredentialStatus";
+
 export function Settings() {
+  const queryClient = useQueryClient();
+  const [userId, setUserId] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [expiresIn, setExpiresIn] = useState("5184000"); // 60일 (초 단위)
+
+  // Credential 정보 조회
+  const {
+    data: credential,
+    isLoading: isLoadingCredential,
+    error: credentialError,
+  } = useQuery({
+    queryKey: ["instagram-credential"],
+    queryFn: () => InstagramService.getCredential(),
+    retry: 1,
+  });
+
+  // Credential 업데이트 mutation
+  const updateMutation = useMutation({
+    mutationFn: (data: { user_id: string; access_token: string; expires_in: number }) =>
+      InstagramService.upsertCredential(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["instagram-credential"] });
+      alert("Instagram Credential이 성공적으로 업데이트되었습니다.");
+      setUserId("");
+      setAccessToken("");
+      setExpiresIn("5184000");
+    },
+    onError: (error: Error) => {
+      alert(error.message || "Failed to update credential");
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!userId.trim() || !accessToken.trim()) {
+      alert("User ID와 Access Token을 모두 입력해주세요.");
+      return;
+    }
+
+    const expiresInNumber = parseInt(expiresIn);
+    if (isNaN(expiresInNumber) || expiresInNumber <= 0) {
+      alert("유효한 만료 기간을 입력해주세요.");
+      return;
+    }
+
+    updateMutation.mutate({
+      user_id: userId.trim(),
+      access_token: accessToken.trim(),
+      expires_in: expiresInNumber,
+    });
+  };
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-800 mb-6">설정</h1>
-      <div className="bg-white rounded-lg shadow p-6">
-        <p className="text-gray-600">설정 페이지입니다.</p>
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold mb-2">설정</h1>
+        <p className="text-gray-600">Instagram API 연동 설정을 관리합니다.</p>
+      </div>
+
+      {/* Current Credential Status */}
+      {isLoadingCredential ? (
+        <div className="bg-white border rounded-md p-6">
+          <div className="flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
+            <span className="ml-2 text-gray-600">Credential 정보 조회 중...</span>
+          </div>
+        </div>
+      ) : credentialError ? (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-yellow-600 mt-0.5" />
+            <div>
+              <h3 className="text-yellow-800 font-semibold mb-1">
+                Instagram Credential 미설정
+              </h3>
+              <p className="text-yellow-600 text-sm">
+                아래 폼을 통해 Instagram Access Token을 설정해주세요.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : credential ? (
+        <div>
+          <h2 className="text-lg font-semibold mb-3">현재 Credential 상태</h2>
+          <CredentialStatus credential={credential} />
+        </div>
+      ) : null}
+
+      {/* Update Credential Form */}
+      <div className="bg-white border rounded-md p-6">
+        <h2 className="text-lg font-semibold mb-4">Instagram Credential 업데이트</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* User ID */}
+          <div className="space-y-2">
+            <Label htmlFor="userId">Instagram Business Account User ID</Label>
+            <div className="relative">
+              <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                id="userId"
+                type="text"
+                placeholder="예: 17841234567890123"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                disabled={updateMutation.isPending}
+                className="pl-10"
+              />
+            </div>
+            <p className="text-sm text-gray-500">
+              Instagram Business Account의 User ID를 입력하세요.
+            </p>
+          </div>
+
+          {/* Access Token */}
+          <div className="space-y-2">
+            <Label htmlFor="accessToken">Access Token (Long-lived)</Label>
+            <div className="relative">
+              <Key className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+              <Textarea
+                id="accessToken"
+                placeholder="IGQW..."
+                value={accessToken}
+                onChange={(e) => setAccessToken(e.target.value)}
+                disabled={updateMutation.isPending}
+                rows={4}
+                className="pl-10 font-mono text-sm"
+              />
+            </div>
+            <p className="text-sm text-gray-500">
+              Instagram Graph API의 Long-lived Access Token을 입력하세요. (유효기간: 60일)
+            </p>
+          </div>
+
+          {/* Expires In */}
+          <div className="space-y-2">
+            <Label htmlFor="expiresIn">만료 기간 (초 단위)</Label>
+            <Input
+              id="expiresIn"
+              type="number"
+              value={expiresIn}
+              onChange={(e) => setExpiresIn(e.target.value)}
+              disabled={updateMutation.isPending}
+              min="1"
+            />
+            <p className="text-sm text-gray-500">
+              기본값: 5184000초 (60일). Long-lived Token의 유효기간을 입력하세요.
+            </p>
+          </div>
+
+          {/* Submit Button */}
+          <Button type="submit" disabled={updateMutation.isPending} className="w-full">
+            {updateMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                업데이트 중...
+              </>
+            ) : (
+              <>
+                <CheckCircle className="h-4 w-4 mr-2" />
+                Credential 업데이트
+              </>
+            )}
+          </Button>
+        </form>
+      </div>
+
+      {/* Info Box */}
+      <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
+        <h3 className="text-blue-800 font-semibold mb-2">
+          📌 Instagram Access Token 발급 방법
+        </h3>
+        <ol className="text-sm text-blue-700 space-y-1 list-decimal list-inside">
+          <li>Meta Developers Console에서 Facebook 앱 생성</li>
+          <li>Instagram Basic Display API 설정</li>
+          <li>Instagram Business Account 연결</li>
+          <li>단기 Access Token 발급</li>
+          <li>장기 토큰으로 교환 (60일)</li>
+          <li>위 폼에 User ID와 Access Token 입력</li>
+        </ol>
+        <p className="text-sm text-blue-600 mt-3">
+          💡 Credential은 암호화되어 서버에 저장됩니다. super_admin 권한이 필요합니다.
+        </p>
       </div>
     </div>
   );

--- a/src/services/instagram.service.ts
+++ b/src/services/instagram.service.ts
@@ -1,0 +1,192 @@
+/**
+ * Instagram Service
+ * Edge Functions API를 사용한 Instagram 해시태그 및 Credentials 관리
+ */
+
+import { supabase } from "@/lib/supabase";
+
+// Edge Functions Base URL
+const EDGE_FUNCTION_URL = import.meta.env.VITE_SUPABASE_URL + "/functions/v1";
+
+// Types
+export interface InstagramHashtag {
+  id: string;
+  keyword: string;
+  hashtag_id: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InstagramCredential {
+  user_id: string;
+  expires_at: string;
+  days_remaining: number;
+  is_expiring_soon: boolean;
+  created_at: string;
+}
+
+export interface InstagramHashtagListResponse {
+  data: InstagramHastagsRes;
+  success: boolean;
+}
+
+export interface InstagramHastagsRes {
+  hashtags: InstagramHashtag[];
+  total: number;
+  within_7_days_count: number;
+  limit_info: {
+    max_hashtags_per_7_days: number;
+    current_count: number;
+    remaining: number;
+  };
+}
+
+export interface UpsertCredentialRequest {
+  access_token: string;
+  user_id: string;
+  expires_in?: number;
+}
+
+export interface SearchHashtagRequest {
+  keyword: string;
+}
+
+/**
+ * Edge Function 호출 헬퍼
+ */
+async function callEdgeFunction<T>(
+  path: string,
+  options?: RequestInit
+): Promise<T> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    throw new Error("No active session");
+  }
+
+  const response = await fetch(`${EDGE_FUNCTION_URL}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || "Unknown error occurred");
+  }
+
+  return response.json();
+}
+
+/**
+ * Instagram Service Class
+ */
+export class InstagramService {
+  // ==================== Credentials ====================
+
+  /**
+   * Instagram Credential 정보 조회
+   */
+  static async getCredential(): Promise<InstagramCredential> {
+    return callEdgeFunction<InstagramCredential>("/instagram-credentials-get", {
+      method: "GET",
+    });
+  }
+
+  /**
+   * Instagram Credential 업데이트 (Upsert)
+   */
+  static async upsertCredential(
+    data: UpsertCredentialRequest
+  ): Promise<{ success: boolean; credential: Partial<InstagramCredential> }> {
+    return callEdgeFunction("/instagram-credentials-upsert", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  // ==================== Hashtags ====================
+
+  /**
+   * 해시태그 목록 조회
+   */
+  static async listHashtags(): Promise<InstagramHashtagListResponse> {
+    return callEdgeFunction<InstagramHashtagListResponse>(
+      "/instagram-hashtags-list",
+      {
+        method: "GET",
+      }
+    );
+  }
+
+  /**
+   * 해시태그 검색 및 등록
+   */
+  static async searchHashtag(keyword: string): Promise<InstagramHashtag> {
+    const response = await callEdgeFunction<{ success: boolean; data: InstagramHashtag }>(
+      "/instagram-hashtags-search",
+      {
+        method: "POST",
+        body: JSON.stringify({ keyword }),
+      }
+    );
+    return response.data;
+  }
+
+  /**
+   * 해시태그 활성화/비활성화 토글
+   */
+  static async toggleHashtag(hashtagId: string): Promise<InstagramHashtag> {
+    const response = await callEdgeFunction<{ success: boolean; data: InstagramHashtag }>(
+      "/instagram-hashtags-toggle",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ hashtag_id: hashtagId }),
+      }
+    );
+    return response.data;
+  }
+
+  // ==================== Utility Functions ====================
+
+  /**
+   * 7일 경과 여부 확인
+   */
+  static isExpiredHashtag(createdAt: string): boolean {
+    const created = new Date(createdAt);
+    const now = new Date();
+    const diffInDays =
+      (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24);
+    return diffInDays > 7;
+  }
+
+  /**
+   * 해시태그 추가 가능 여부 확인
+   */
+  static canAddMoreHashtags(hashtags: InstagramHashtag[]): boolean {
+    const activeWithin7Days = hashtags.filter(
+      (h) => !this.isExpiredHashtag(h.created_at)
+    );
+    return activeWithin7Days.length < 30;
+  }
+
+  /**
+   * 7일 이내 등록된 해시태그 개수
+   */
+  static getWithin7DaysCount(hashtags: InstagramHashtag[]): number {
+    return hashtags.filter((h) => !this.isExpiredHashtag(h.created_at)).length;
+  }
+
+  /**
+   * Credential 만료 임박 여부 확인
+   */
+  static isCredentialExpiringSoon(daysRemaining: number): boolean {
+    return daysRemaining <= 7;
+  }
+}

--- a/src/services/menu.service.ts
+++ b/src/services/menu.service.ts
@@ -40,8 +40,8 @@ export interface CreateMenuRequest {
   name: string;
   description?: string;
   parent_id?: string;
-  path?: string;
-  icon?: string;
+  path?: string | null;
+  icon?: string | null;
   display_order?: number;
   is_active?: boolean;
   metadata?: Record<string, any>;
@@ -52,8 +52,8 @@ export interface UpdateMenuRequest {
   name?: string;
   description?: string;
   parent_id?: string;
-  path?: string;
-  icon?: string;
+  path?: string | null;
+  icon?: string | null;
   display_order?: number;
   is_active?: boolean;
   metadata?: Record<string, any>;


### PR DESCRIPTION
## Summary

Instagram Graph API를 활용한 해시태그 관리 시스템을 구축했습니다. 관리자가 Instagram 비즈니스 계정의 Access Token을 등록하고, 해시태그를 검색/등록/관리할 수 있는 완전한 UI와 서비스 레이어를 제공합니다.

## Changes

### 1. Database Schema Documentation
- `docs/database/tables/instagram_hashtags.md` - Instagram 해시태그 테이블 스키마 문서
- `docs/database/tables/instagram_credentials.md` - Instagram 인증 정보 테이블 스키마 문서

### 2. Service Layer
- `src/services/instagram.service.ts` - Instagram Edge Functions API 연동 서비스
  - Credential 관리 (조회, 업데이트)
  - 해시태그 관리 (목록 조회, 검색/등록, 활성화 토글)
  - 유틸리티 함수 (7일 경과 확인, 등록 가능 여부 체크)

### 3. UI Components
- `src/components/instagram/HashtagsTable.tsx` - 해시태그 목록 테이블
- `src/components/instagram/AddHashtagDialog.tsx` - 해시태그 추가 다이얼로그
- `src/components/instagram/CredentialStatus.tsx` - Access Token 상태 표시 컴포넌트

### 4. Pages
- `src/pages/InstagramHashtags.tsx` - 해시태그 관리 페이지 (완전 구현)
  - 해시태그 목록 조회 및 테이블 표시
  - 7일 제한 정보 표시 (Instagram API 정책: 7일간 최대 30개)
  - 해시태그 검색 및 등록
  - 활성화/비활성화 토글
  - 실시간 상태 업데이트
- `src/pages/Settings.tsx` - Instagram Credential 설정 섹션 추가

### 5. Navigation & Routing
- `src/App.tsx` - Instagram 해시태그 페이지 라우팅 추가
- `src/components/layout/GNB.tsx` - Instagram 메뉴 추가
- `src/components/layout/Sidebar.tsx` - Instagram 메뉴 항목 추가

### 6. Storage Utility
- `src/lib/instagram-storage.ts` - localStorage 기반 Credential 임시 저장 (향후 서버 저장 전환 예정)

### 7. Code Quality Improvements
- `src/components/admin/MenuFormDialog.tsx` - 타입 정확도 향상 및 폼 개선
- `src/features/store/components/StoreListTable.tsx` - 코드 포매팅 개선
- `src/services/menu.service.ts` - 메뉴 서비스 개선

## Technical Details

### Instagram API Integration
- **API Version**: Facebook Graph API v24.0
- **Authentication**: Long-lived Access Token (60일 유효)
- **Rate Limits**: 7일간 최대 30개의 고유 해시태그 검색 가능
- **Endpoints Used**:
  - `ig_hashtag_search` - 해시태그 검색 및 ID 조회
  - (향후) `{hashtag_id}/recent_media` - 해시태그별 최근 미디어 조회

### Architecture
- **Service Layer Pattern**: Edge Functions 호출을 캡슐화한 서비스 클래스
- **React Query**: 서버 상태 관리 및 캐싱
- **Type Safety**: 엄격한 TypeScript 타입 정의
- **Component Composition**: 재사용 가능한 컴포넌트 구조

### Key Features
1. **해시태그 관리**
   - Instagram Graph API를 통한 해시태그 검색
   - 검색된 해시태그 자동 등록
   - 활성화/비활성화 토글
   - 7일 제한 실시간 모니터링

2. **Credential 관리**
   - Access Token 및 Business Account ID 설정
   - 만료 정보 표시
   - 만료 임박 알림 (7일 이내)

3. **UI/UX**
   - 직관적인 관리 인터페이스
   - 실시간 상태 업데이트
   - 로딩 및 에러 상태 처리
   - 제한사항 명확한 안내

## Testing

### Manual Testing Checklist
- [ ] Instagram 메뉴 접근 및 페이지 로드 확인
- [ ] 해시태그 목록 조회 동작 확인
- [ ] 해시태그 검색 및 등록 기능 테스트
- [ ] 활성화/비활성화 토글 동작 확인
- [ ] 7일 제한 정보 정확성 검증
- [ ] Credential 설정 페이지 동작 확인
- [ ] 에러 처리 및 로딩 상태 확인

### Edge Function Dependencies
이 PR은 프론트엔드 변경사항만 포함하며, 다음 Edge Functions가 배포되어 있어야 정상 작동합니다:
- `instagram-credentials-get`
- `instagram-credentials-upsert`
- `instagram-hashtags-list`
- `instagram-hashtags-search`
- `instagram-hashtags-toggle`

## Migration Notes

### Database Tables Required
- `instagram_hashtags` - 해시태그 정보 저장
- `instagram_credentials` - Access Token 저장 (암호화)

자세한 스키마는 다음 문서를 참조하세요:
- `/Users/kyusik/Desktop/gacha-store-admin/docs/database/tables/instagram_hashtags.md`
- `/Users/kyusik/Desktop/gacha-store-admin/docs/database/tables/instagram_credentials.md`

## Screenshots

(실제 배포 후 스크린샷 추가 권장)
- Instagram 해시태그 관리 페이지
- 해시태그 추가 다이얼로그
- 7일 제한 정보 표시

## Related Issues

(관련 이슈 번호가 있다면 여기에 추가)

## Breaking Changes

없음. 신규 기능 추가이며 기존 기능에 영향을 주지 않습니다.

## Future Improvements

1. **Credential Refresh Token 자동 갱신**: 만료 7일 전 자동 토큰 갱신
2. **다중 Instagram 계정 지원**: 여러 비즈니스 계정 관리
3. **Recent Media 조회**: 해시태그별 최근 미디어 자동 수집
4. **Analytics Dashboard**: 해시태그별 통계 및 인사이트

## Commits

- a2213f9 - docs : Instagram API 데이터베이스 스키마 문서 추가
- 45533f5 - feat : Instagram API 연동 서비스 레이어 추가
- ad7c385 - feat : Instagram 관리 UI 컴포넌트 추가
- 46df306 - feat : Instagram 해시태그 및 Credential 설정 페이지 구현
- d508b9c - feat : Instagram 메뉴 및 라우팅 연동
- 93e877b - refactor : 메뉴 관리 폼 개선 및 타입 정확도 향상
- 7c7fa6b - style : StoreListTable 코드 포매팅 개선

---

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>